### PR TITLE
feat: add accountabilibot.wiki submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "accountabilibot.wiki"]
+	path = accountabilibot.wiki
+	url = https://github.com/jartis/accountabilibot.wiki.git


### PR DESCRIPTION
These changes will let anyone who clones also be able to edit the wiki easily within the main directory, in `accountabilitbot.wiki`.

Also if we don't like that path (maybe just `docs` or `wiki` as suggested earlier), I can change the submodule path.